### PR TITLE
Fix reference to data.json in docs/index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,6 @@
     <title>Document</title>
 </head>
 <body>
-    The wasm builds data is at <a href="/data.json">data.json</a>
+    The wasm builds data is at <a href="./data.json">data.json</a>
 </body>
 </html>


### PR DESCRIPTION
The `data.json` link at https://lfortran.github.io/wasm_builds/ points to https://lfortran.github.io/data.json which is invalid. It should point to https://lfortran.github.io/wasm_builds/data.json.

This `PR` fixes the above issue.